### PR TITLE
Fix incorrect link to bml

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Structure Solver. **LA-CC-16-068**
   commonly used in _quantum chemistry packages_.
 
 - This library has to be compiled with the [_Basic Matrix Library_
-  (BML)](https://qmmd.github.io/bml/).
+  (BML)](https://lanl.github.io/bml/).
 
 - Our webpage can be found at https://lanl.github.io/qmd-progress/
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Structure Solver. **LA-CC-16-068**
   commonly used in _quantum chemistry packages_.
 
 - This library has to be compiled with the [_Basic Matrix Library_
-  (BML)](https://qmmd.github.io/bml/).
+  (BML)](https://lanl.github.io/bml/).
 
 ## Authors
 


### PR DESCRIPTION
The URL to the bml was incorrect.

Fixes: https://github.com/lanl/qmd-progress/issues/109